### PR TITLE
Setting after_n_builds higher

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -5,4 +5,4 @@ codecov:
 
 comment:
   layout: "files"
-  behavior: "update"
+

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,3 +1,8 @@
+
+codecov:
+  notify:
+    after_n_builds: 10
+
 comment:
   layout: "files"
   behavior: "update"


### PR DESCRIPTION
This a test two, since I will be uploading from a number of CI providers, I went with a higher number of 10

https://docs.codecov.io/docs/pull-request-comments#section-after_n_builds

This should not have a Codecov status or comment.