### PR TITLE
Tell Renovate not to upgrade nginx

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -2,14 +2,18 @@
     extends: ["config:best-practices", ":automergeStableNonMajor"],
     packageRules: [
         {
-            excludePackageNames: [
+            "allowedVersions": "1.9.8",
+            "matchDatasources": [
+                "docker"
+            ],
+            "matchPackageNames": [
                 // Prevent automatic updates from nginx:1.9.8
                 // While this image can still be found on DockerHub,
                 // it is also archived at https://archive.org/details/nginx_1.9.8.tar
                 // This is required to serve as a proxy to the [SChannel](https://web.archive.org/web/20230402130420/https://learn.microsoft.com/en-us/windows/win32/com/schannel) that Windows XP uses.
                 // Windows XP is required support since the legacy client can not be upgraded or modified.
-                "nginx",
-            ],
-        },
+                "nginx"
+            ]
+        }
     ],
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated the Renovate configuration to specify allowed versions and exclude certain datasources and package names.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->