### PR TITLE
chore: pin images to version

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,7 +11,7 @@ services:
         extra_hosts:
             - "host.docker.internal:host-gateway"
     db:
-        image: postgres:latest
+        image: postgres:16.2
         restart: always
         environment:
             POSTGRES_DB: rm
@@ -25,7 +25,7 @@ services:
             - no-new-privileges:true
 
     adminer:
-        image: adminer
+        image: adminer:4.8.1
         restart: always
         ports:
             - 8080:8080

--- a/services/sslProxy/Dockerfile
+++ b/services/sslProxy/Dockerfile
@@ -1,5 +1,5 @@
 # Can be located at https://archive.org/details/nginx_1.9.8.tar if needed
-FROM nginx:1.9.8@sha256:5d3b56065cf133f8968a557bf49c639320b2fc4c57c635b5707978fb6b738e1f as base
+FROM nginx:1.9.8 as base
 
 COPY nginx.conf /etc/nginx/nginx.conf
 COPY mcouniverse.pem /etc/nginx/mcouniverse.pem


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
	- Updated `postgres` service to use version `16.2` and `adminer` service to version `4.8.1` in `docker-compose.yml`.
	- Simplified the SSL proxy service Dockerfile for better maintainability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->