### PR TITLE
feat: add chat utility functions and tests

### DIFF
--- a/src/chat/assertLength.test.ts
+++ b/src/chat/assertLength.test.ts
@@ -10,14 +10,41 @@ describe("assertLength", () => {
 		expect(() => assertLength(4, 5)).toThrow("Expected length 5, but got 4");
 	});
 
-	describe("assertLength", () => {
-		it("should not throw an error when actual length matches expected length", () => {
-			expect(() => assertLength(5, 5)).not.toThrow();
-		});
+	it("should throw an error with the correct message when lengths do not match", () => {
+		expect(() => assertLength(3, 5)).toThrow(Error);
+		expect(() => assertLength(3, 5)).toThrow("Expected length 5, but got 3");
+	});
 
-		it("should throw an error when actual length does not match expected length", () => {
-			expect(() => assertLength(4, 5)).toThrow("Expected length 5, but got 4");
-		});
+	it("should not throw an error for zero lengths when they match", () => {
+		expect(() => assertLength(0, 0)).not.toThrow();
+	});
+
+	it("should throw an error for zero actual length when expected length is non-zero", () => {
+		expect(() => assertLength(0, 1)).toThrow("Expected length 1, but got 0");
+	});
+
+	it("should throw an error for non-zero actual length when expected length is zero", () => {
+		expect(() => assertLength(1, 0)).toThrow("Expected length 0, but got 1");
+	});
+
+	it("should throw an error when actual length is negative", () => {
+		expect(() => assertLength(-1, 5)).toThrow("Expected length 5, but got -1");
+	});
+
+	it("should throw an error when expected length is negative", () => {
+		expect(() => assertLength(5, -1)).toThrow("Expected length -1, but got 5");
+	});
+
+	it("should not throw an error for very large matching lengths", () => {
+		const largeNumber = Number.MAX_SAFE_INTEGER;
+		expect(() => assertLength(largeNumber, largeNumber)).not.toThrow();
+	});
+
+	it("should throw an error for very large non-matching lengths", () => {
+		const largeNumber = Number.MAX_SAFE_INTEGER;
+		expect(() => assertLength(largeNumber, largeNumber - 1)).toThrow(`Expected length ${largeNumber - 1}, but got ${largeNumber}`);
+	});
+});
 
 		it("should throw an error with the correct message when lengths do not match", () => {
 			expect(() => assertLength(3, 5)).toThrow(Error);

--- a/src/chat/assertLength.test.ts
+++ b/src/chat/assertLength.test.ts
@@ -10,12 +10,30 @@ describe("assertLength", () => {
 		expect(() => assertLength(4, 5)).toThrow("Expected length 5, but got 4");
 	});
 
-	it("should throw an error with the correct message when lengths do not match", () => {
-		try {
-			assertLength(3, 5);
-		} catch (e) {
-			expect(e).toBeInstanceOf(Error);
-			expect((e as Error).message).toBe("Expected length 5, but got 3");
-		}
+	describe("assertLength", () => {
+		it("should not throw an error when actual length matches expected length", () => {
+			expect(() => assertLength(5, 5)).not.toThrow();
+		});
+
+		it("should throw an error when actual length does not match expected length", () => {
+			expect(() => assertLength(4, 5)).toThrow("Expected length 5, but got 4");
+		});
+
+		it("should throw an error with the correct message when lengths do not match", () => {
+			expect(() => assertLength(3, 5)).toThrow(Error);
+			expect(() => assertLength(3, 5)).toThrow("Expected length 5, but got 3");
+		});
+
+		it("should not throw an error for zero lengths when they match", () => {
+			expect(() => assertLength(0, 0)).not.toThrow();
+		});
+
+		it("should throw an error for zero actual length when expected length is non-zero", () => {
+			expect(() => assertLength(0, 1)).toThrow("Expected length 1, but got 0");
+		});
+
+		it("should throw an error for non-zero actual length when expected length is zero", () => {
+			expect(() => assertLength(1, 0)).toThrow("Expected length 0, but got 1");
+		});
 	});
 });

--- a/src/chat/assertLength.test.ts
+++ b/src/chat/assertLength.test.ts
@@ -1,0 +1,21 @@
+import { describe, it, expect } from "vitest";
+import { assertLength } from "./assertLength.js";
+
+describe("assertLength", () => {
+	it("should not throw an error when actual length matches expected length", () => {
+		expect(() => assertLength(5, 5)).not.toThrow();
+	});
+
+	it("should throw an error when actual length does not match expected length", () => {
+		expect(() => assertLength(4, 5)).toThrow("Expected length 5, but got 4");
+	});
+
+	it("should throw an error with the correct message when lengths do not match", () => {
+		try {
+			assertLength(3, 5);
+		} catch (e) {
+			expect(e).toBeInstanceOf(Error);
+			expect((e as Error).message).toBe("Expected length 5, but got 3");
+		}
+	});
+});

--- a/src/chat/assertLength.test.ts
+++ b/src/chat/assertLength.test.ts
@@ -42,25 +42,8 @@ describe("assertLength", () => {
 
 	it("should throw an error for very large non-matching lengths", () => {
 		const largeNumber = Number.MAX_SAFE_INTEGER;
-		expect(() => assertLength(largeNumber, largeNumber - 1)).toThrow(`Expected length ${largeNumber - 1}, but got ${largeNumber}`);
-	});
-});
-
-		it("should throw an error with the correct message when lengths do not match", () => {
-			expect(() => assertLength(3, 5)).toThrow(Error);
-			expect(() => assertLength(3, 5)).toThrow("Expected length 5, but got 3");
-		});
-
-		it("should not throw an error for zero lengths when they match", () => {
-			expect(() => assertLength(0, 0)).not.toThrow();
-		});
-
-		it("should throw an error for zero actual length when expected length is non-zero", () => {
-			expect(() => assertLength(0, 1)).toThrow("Expected length 1, but got 0");
-		});
-
-		it("should throw an error for non-zero actual length when expected length is zero", () => {
-			expect(() => assertLength(1, 0)).toThrow("Expected length 0, but got 1");
-		});
+		expect(() => assertLength(largeNumber, largeNumber - 1)).toThrow(
+			`Expected length ${largeNumber - 1}, but got ${largeNumber}`,
+		);
 	});
 });

--- a/src/chat/assertLength.ts
+++ b/src/chat/assertLength.ts
@@ -1,0 +1,14 @@
+/**
+ * Asserts that the actual length matches the expected length.
+ * 
+ * @param actualLength - The actual length to be checked.
+ * @param expectedLength - The expected length to compare against.
+ * @throws {Error} Throws an error if the actual length does not match the expected length.
+ */
+export function assertLength(actualLength: number, expectedLength: number): void {
+    if (actualLength !== expectedLength) {
+        throw new Error(
+            `Expected length ${expectedLength}, but got ${actualLength}`,
+        );
+    }
+}

--- a/src/chat/timestampToTimeT.test.ts
+++ b/src/chat/timestampToTimeT.test.ts
@@ -1,0 +1,29 @@
+import { describe, it, expect } from "vitest";
+import { timestampToTime32T } from "./timestampToTimeT.js";
+
+describe("timestampToTime32T", () => {
+	it("should convert milliseconds to seconds correctly", () => {
+		expect(timestampToTime32T(1000)).toBe(1);
+		expect(timestampToTime32T(2000)).toBe(2);
+		expect(timestampToTime32T(1500)).toBe(1);
+		expect(timestampToTime32T(0)).toBe(0);
+	});
+
+	it("should handle large timestamps correctly", () => {
+		expect(timestampToTime32T(1609459200000)).toBe(1609459200); // 2021-01-01T00:00:00Z
+	});
+
+	it("should handle negative timestamps correctly", () => {
+		expect(timestampToTime32T(-1000)).toBe(-1);
+		expect(timestampToTime32T(-2000)).toBe(-2);
+	});
+
+	it("should handle edge cases correctly", () => {
+		expect(timestampToTime32T(Number.MAX_SAFE_INTEGER)).toBe(
+			Math.floor(Number.MAX_SAFE_INTEGER / 1000),
+		);
+		expect(timestampToTime32T(Number.MIN_SAFE_INTEGER)).toBe(
+			Math.floor(Number.MIN_SAFE_INTEGER / 1000),
+		);
+	});
+});

--- a/src/chat/timestampToTimeT.ts
+++ b/src/chat/timestampToTimeT.ts
@@ -1,0 +1,9 @@
+/**
+ * Converts a given timestamp in milliseconds to a 32-bit time value in seconds.
+ *
+ * @param timestamp - The timestamp in milliseconds.
+ * @returns The converted time value in seconds.
+ */
+export function timestampToTime32T(timestamp: number): number {
+    return Math.floor(timestamp / 1000);
+}

--- a/src/chat/toHexString.test.ts
+++ b/src/chat/toHexString.test.ts
@@ -1,0 +1,30 @@
+import { describe, it, expect } from "vitest";
+import { bufferToHexString } from "./toHexString.js";
+
+describe("bufferToHexString", () => {
+	it("should convert a buffer to a hexadecimal string", () => {
+		const buffer = Buffer.from([0x00, 0xff, 0x10, 0x20]);
+		const hexString = bufferToHexString(buffer);
+		expect(hexString).toBe("00ff1020");
+	});
+
+	it("should handle an empty buffer", () => {
+		const buffer = Buffer.from([]);
+		const hexString = bufferToHexString(buffer);
+		expect(hexString).toBe("");
+	});
+
+	it("should pad single digit hex values with a leading zero", () => {
+		const buffer = Buffer.from([0x1]);
+		const hexString = bufferToHexString(buffer);
+		expect(hexString).toBe("01");
+	});
+
+	it("should handle a buffer with multiple bytes", () => {
+		const buffer = Buffer.from([
+			0x12, 0x34, 0x56, 0x78, 0x9a, 0xbc, 0xde, 0xf0,
+		]);
+		const hexString = bufferToHexString(buffer);
+		expect(hexString).toBe("123456789abcdef0");
+	});
+});

--- a/src/chat/toHexString.test.ts
+++ b/src/chat/toHexString.test.ts
@@ -27,4 +27,46 @@ describe("bufferToHexString", () => {
 		const hexString = bufferToHexString(buffer);
 		expect(hexString).toBe("123456789abcdef0");
 	});
+
+	it("should handle null input gracefully", () => {
+		expect(() => bufferToHexString(null as any)).toThrow();
+	});
+
+	it("should handle undefined input gracefully", () => {
+		expect(() => bufferToHexString(undefined as any)).toThrow();
+	});
+
+	it("should handle a very large buffer", () => {
+		const largeBuffer = Buffer.alloc(10 ** 6, 0xff); // 1MB buffer filled with 0xff
+		const hexString = bufferToHexString(largeBuffer);
+		expect(hexString.length).toBe(2 * largeBuffer.length);
+		expect(hexString).toMatch(/^ff+$/);
+	});
+
+	it("should handle a buffer with Unicode characters", () => {
+		const buffer = Buffer.from("你好", "utf8");
+		const hexString = bufferToHexString(buffer);
+		expect(hexString).toBe(buffer.toString("hex"));
+	});
+
+	// Additional tests
+	it("should handle a buffer with mixed byte values", () => {
+		const buffer = Buffer.from([0x00, 0x7f, 0x80, 0xff]);
+		const hexString = bufferToHexString(buffer);
+		expect(hexString).toBe("007f80ff");
+	});
+
+	it("should handle a buffer with all possible byte values", () => {
+		const buffer = Buffer.from(Array.from({ length: 256 }, (_, i) => i));
+		const hexString = bufferToHexString(buffer);
+		expect(hexString).toBe(
+			"000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f202122232425262728292a2b2c2d2e2f303132333435363738393a3b3c3d3e3f404142434445464748494a4b4c4d4e4f505152535455565758595a5b5c5d5e5f606162636465666768696a6b6c6d6e6f707172737475767778797a7b7c7d7e7f808182838485868788898a8b8c8d8e8f909192939495969798999a9b9c9d9e9fa0a1a2a3a4a5a6a7a8a9aaabacadaeafb0b1b2b3b4b5b6b7b8b9babbbcbdbebfc0c1c2c3c4c5c6c7c8c9cacbcccdcecfd0d1d2d3d4d5d6d7d8d9dadbdcdddedfe0e1e2e3e4e5e6e7e8e9eaebecedeeeff0f1f2f3f4f5f6f7f8f9fafbfcfdfeff"
+		);
+	});
+
+	it("should handle a buffer with non-printable ASCII characters", () => {
+		const buffer = Buffer.from([0x00, 0x1f, 0x7f, 0x80]);
+		const hexString = bufferToHexString(buffer);
+		expect(hexString).toBe("001f7f80");
+	});
 });

--- a/src/chat/toHexString.ts
+++ b/src/chat/toHexString.ts
@@ -5,5 +5,8 @@
  * @returns The hexadecimal string representation of the buffer.
  */
 export function bufferToHexString(buffer: Buffer): string {
-	return buffer.toString("hex").padStart(2, "0");
+	return buffer.reduce(
+		(str, byte) => str + byte.toString(16).padStart(2, "0"),
+		"",
+	);
 }

--- a/src/chat/toHexString.ts
+++ b/src/chat/toHexString.ts
@@ -1,0 +1,9 @@
+/**
+ * Converts a Buffer to a hexadecimal string representation.
+ *
+ * @param buffer - The Buffer to be converted.
+ * @returns The hexadecimal string representation of the buffer.
+ */
+export function bufferToHexString(buffer: Buffer): string {
+	return buffer.toString("hex").padStart(2, "0");
+}

--- a/src/chat/writeShortBoolean.test.ts
+++ b/src/chat/writeShortBoolean.test.ts
@@ -1,0 +1,28 @@
+import { describe, it, expect } from "vitest";
+import { writeShortBooleanBE } from "./writeShortBoolean.js";
+
+describe("writeShortBooleanBE", () => {
+	it("should write 1 for true at the specified offset", () => {
+		const buffer = Buffer.alloc(4);
+		writeShortBooleanBE(buffer, 2, true);
+		expect(buffer.readUInt16BE(2)).toBe(1);
+	});
+
+	it("should write 0 for false at the specified offset", () => {
+		const buffer = Buffer.alloc(4);
+		writeShortBooleanBE(buffer, 2, false);
+		expect(buffer.readUInt16BE(2)).toBe(0);
+	});
+
+	it("should not affect other parts of the buffer", () => {
+		const buffer = Buffer.alloc(4);
+		buffer.writeUInt16BE(0x1234, 0);
+		writeShortBooleanBE(buffer, 2, true);
+		expect(buffer.readUInt16BE(0)).toBe(0x1234);
+	});
+
+	it("should throw an error if the offset is out of bounds", () => {
+		const buffer = Buffer.alloc(2);
+		expect(() => writeShortBooleanBE(buffer, 2, true)).toThrow();
+	});
+});

--- a/src/chat/writeShortBoolean.ts
+++ b/src/chat/writeShortBoolean.ts
@@ -1,0 +1,14 @@
+/**
+ * Writes a boolean value to a buffer at the specified offset in big-endian format.
+ *
+ * @param buffer - The buffer to write to.
+ * @param offset - The offset in the buffer where the boolean value should be written.
+ * @param value - The boolean value to write. `true` will be written as 1, and `false` will be written as 0.
+ */
+export function writeShortBooleanBE(
+	buffer: Buffer,
+	offset: number,
+	value: boolean,
+): void {
+	buffer.writeUInt16BE(value ? 1 : 0, offset);
+}

--- a/src/chat/writeShortBoolean.ts
+++ b/src/chat/writeShortBoolean.ts
@@ -10,5 +10,8 @@ export function writeShortBooleanBE(
 	offset: number,
 	value: boolean,
 ): void {
+	if (offset < 0 || offset + 2 > buffer.length) {
+		throw new RangeError('Attempt to write outside buffer bounds');
+	}
 	buffer.writeUInt16BE(value ? 1 : 0, offset);
 }

--- a/src/chat/writeZeroTerminatedString.test.ts
+++ b/src/chat/writeZeroTerminatedString.test.ts
@@ -1,0 +1,62 @@
+import { describe, it, expect } from "vitest";
+import { writeZeroTerminatedString } from "./writeZeroTerminatedString.js";
+
+describe("writeZeroTerminatedString", () => {
+	it("should write a zero-terminated string to the buffer at the specified offset", () => {
+		const buffer = Buffer.alloc(20);
+		const offset = 5;
+		const value = "hello";
+
+		const newOffset = writeZeroTerminatedString(buffer, offset, value);
+
+		expect(buffer.toString("utf8", offset, offset + value.length)).toBe(value);
+		expect(buffer.readUInt8(offset + value.length)).toBe(0);
+		expect(newOffset).toBe(offset + value.length + 1);
+	});
+
+	it("should handle an empty string correctly", () => {
+		const buffer = Buffer.alloc(10);
+		const offset = 2;
+		const value = "";
+
+		const newOffset = writeZeroTerminatedString(buffer, offset, value);
+
+		expect(buffer.readUInt8(offset)).toBe(0);
+		expect(newOffset).toBe(offset + 1);
+	});
+
+	it("should overwrite existing data in the buffer", () => {
+		const buffer = Buffer.from("abcdefghij");
+		const offset = 3;
+		const value = "xyz";
+
+		const newOffset = writeZeroTerminatedString(buffer, offset, value);
+
+		expect(buffer.toString("utf8", 0, 10)).toBe("abcxyz\0hij");
+		expect(newOffset).toBe(offset + value.length + 1);
+	});
+
+	it("should handle writing at the start of the buffer", () => {
+		const buffer = Buffer.alloc(10);
+		const offset = 0;
+		const value = "start";
+
+		const newOffset = writeZeroTerminatedString(buffer, offset, value);
+
+		expect(buffer.toString("utf8", 0, value.length)).toBe(value);
+		expect(buffer.readUInt8(value.length)).toBe(0);
+		expect(newOffset).toBe(value.length + 1);
+	});
+
+	it("should handle writing at the end of the buffer", () => {
+		const buffer = Buffer.alloc(10);
+		const offset = 5;
+		const value = "end";
+
+		const newOffset = writeZeroTerminatedString(buffer, offset, value);
+
+		expect(buffer.toString("utf8", offset, offset + value.length)).toBe(value);
+		expect(buffer.readUInt8(offset + value.length)).toBe(0);
+		expect(newOffset).toBe(offset + value.length + 1);
+	});
+});

--- a/src/chat/writeZeroTerminatedString.test.ts
+++ b/src/chat/writeZeroTerminatedString.test.ts
@@ -59,4 +59,12 @@ describe("writeZeroTerminatedString", () => {
 		expect(buffer.readUInt8(offset + value.length)).toBe(0);
 		expect(newOffset).toBe(offset + value.length + 1);
 	});
+
+	it("should handle buffer overflow", () => {
+		const buffer = Buffer.alloc(10);
+		const offset = 5;
+		const value = "toolong";  // 7 chars + null terminator > remaining 5 bytes
+
+		expect(() => writeZeroTerminatedString(buffer, offset, value)).toThrow();
+	});
 });

--- a/src/chat/writeZeroTerminatedString.ts
+++ b/src/chat/writeZeroTerminatedString.ts
@@ -1,0 +1,17 @@
+/**
+ * Writes a zero-terminated UTF-8 string to a buffer at the specified offset.
+ *
+ * @param buffer - The buffer to write the string to.
+ * @param offset - The offset in the buffer to start writing the string.
+ * @param value - The string to write to the buffer.
+ * @returns The new offset after writing the string and the zero terminator.
+ */
+export function writeZeroTerminatedString(
+	buffer: Buffer,
+	offset: number,
+	value: string,
+): number {
+	buffer.write(value, offset, value.length, "utf8");
+	buffer.writeUInt8(0, offset + value.length);
+	return offset + value.length + 1;
+}


### PR DESCRIPTION
This pull request adds several utility functions and their corresponding tests to the chat module. The added functions include `assertLength`, `timestampToTime32T`, `writeShortBooleanBE`, `bufferToHexString`, and `writeZeroTerminatedString`. These functions provide helpful functionality for working with buffers and strings in the chat module. The tests ensure that the functions are working correctly and handle various edge cases. This pull request improves the overall functionality and reliability of the chat module.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced several new functions for buffer manipulation, including:
		- `assertLength` for validating lengths.
		- `bufferToHexString` for converting buffers to hexadecimal strings.
		- `writeZeroTerminatedString` for writing zero-terminated strings to buffers.
- **Tests**
	- Added comprehensive unit tests for `assertLength`, `bufferToHexString`, and `writeZeroTerminatedString` functions to ensure expected behavior across various scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->