### PR TITLE
ci: :bug: try to break codecov

### DIFF
--- a/.github/workflows/node.yml
+++ b/.github/workflows/node.yml
@@ -32,6 +32,9 @@ jobs:
               run: |
                   pnpm install
                   make test
+            - name: "Corrupt coverage file"
+              run: |
+                  printf "\xef\xbb\xbf" | cat - packages/gateway/coverage/cobertura-coverage.xml  > packages/gateway/coverage/cobertura-coverage2.xml                  
               env:
                   CODECOV_UPLOAD_BUNDLE_TOKEN: ${{ secrets.CODECOV_UPLOAD_BUNDLE_TOKEN }}
             - name: Codecov install cli

--- a/Makefile
+++ b/Makefile
@@ -20,6 +20,7 @@ certs:
 
 test:
 	@./scripts/run_tests.sh
+	printf "\xef\xbb\xbf" | cat - packages/gateway/coverage/cobertura-coverage.xml  > packages/gateway/coverage/cobertura-coverage2.xml
 
 
 
@@ -27,14 +28,11 @@ test:
 start:
 	@pnpx tsx --import ./instrument.mjs --openssl-legacy-provider --env-file=.env src/server.ts
 
-prod_node:
-	docker-compose --file docker-compose.yml up -d --build
-
 up:
-	docker-compose up -d --build
+	docker compose up -d --build
 
 down:
-	docker-compose down
+	docker compose down
 
 enable-node:
 	@sudo setcap cap_net_bind_service=+ep $(which node)

--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,6 @@ certs:
 
 test:
 	@./scripts/run_tests.sh
-	printf "\xef\xbb\xbf" | cat - packages/gateway/coverage/cobertura-coverage.xml  > packages/gateway/coverage/cobertura-coverage2.xml
 
 
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Added a step in the GitHub Actions workflow to create a corrupted coverage file for testing purposes.

- **Bug Fixes**
	- Updated Docker command syntax to align with the latest CLI standards, ensuring smoother operations.
  
- **Documentation**
	- Added comments regarding the `.env` file to clarify its importance for test execution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->